### PR TITLE
Allow static build of QtWebKit with msvc2012

### DIFF
--- a/Tools/qmake/mkspecs/features/configure.prf
+++ b/Tools/qmake/mkspecs/features/configure.prf
@@ -121,7 +121,7 @@ defineTest(finalizeConfigure) {
     production_build:blackberry|qnx {
         addReasonForSkippingBuild("Build not supported on BB10/QNX yet.")
     }
-    !gnu_thin_archives:!win32-msvc2013:!mingw:contains(QT_CONFIG, static) {
+    !gnu_thin_archives:!win32-msvc2012:!win32-msvc2013:!mingw:contains(QT_CONFIG, static) {
         addReasonForSkippingBuild("QtWebKit cannot be built as a static library on this platform. Check your configuration in qtbase/config.summary.")
     }
     winrt: addReasonForSkippingBuild("QtWebKit is not supported on Windows Phone/Windows RT")


### PR DESCRIPTION
I'm not sure why it wasn't enabled, the build goes fine with this patch. I have asked on the qt development list:
http://lists.qt-project.org/pipermail/development/2015-April/021236.html

At least we can just revert the change again if upstream QtWebKit somehow manages to make the static build not work with msvc 2012 (this seems unlikely as the set of changes between msvc 2012 and 2013 are quite small, and what does it have to do with static builds anyways?).

I'm guessing that this pull request should actually be against wk_custom once we hit "point \#3", but at least here it is in case it could be useful for someone.